### PR TITLE
Fix context

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function nunjucksBuild(opts) {
     var str = file.contents.toString('utf8');
     var data = file.data ? file.data : {};
     var fm = file.frontMatter ? file.frontMatter : {};
-    var context = assign(options.locals, data, fm);
+    var context = assign({}, options.locals, data, fm);
 
     var loader = new nunjucks.FileSystemLoader(options.searchPaths, {
       autoescape: options.autoescape


### PR DESCRIPTION
When using gulp-data, the context was shared with consecutive files.

If we had 2 files, a.html and b.html, and 2 data files loaded with gulp-data, a.json and b.json, where a.json has

```
{
  "title" : "Hello"
}
```

and b.json has 

```
{
  "subtitle": "Sir"
}
```

then b.html will have the following context

```
{
   "title": "Hello",
   "subtitle": "Sir"
}
```
